### PR TITLE
Update index.js for possible crash with RN 0.59.9

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ export default class CachedImage extends Component {
 
         if (this.state.source) {
 
-            const renderImage = (props, children) => (children ?
+            const renderImage = (props, children) => (children != null ?
                 <ImageBackground {...props}>{children}</ImageBackground> :
                 <Image {...props}/>);
 


### PR DESCRIPTION
With RN 0.59.9 which includes new JavaScriptCore and if children was attached with {condition && Component} format and condition is false in non other than null/undefined (false || 0 || ‘’), (false || 0 || ‘’) is returned as children. Since children is (false || 0 || ‘’), it will pick Image component but when it’s returned, props.children is not null/undefined so it will crash as Image component will see it as having children. Checking it against null will make sure that ImageBackground is chosen to prevent crash. Existing module users can prevent crash by making sure null is returned by {condition && Component || null}. Another solution would be to override children if it’s (false || 0 || ‘’) but I figure sometimes less code is better.