### PR TITLE
Fix android crash "Value for uri cannot be cast from ReadableNativeMa…

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,7 +176,7 @@ export default class CachedImage extends Component {
                         // cache failed use original source
                         if (this._mounted) {
                             setTimeout(() => {
-                                this.setState({source: { uri: this.props.source}});
+                                this.setState({source: { uri: this.props.source.uri}});
                         }, 0);
                         }
                         this._downloading = false;


### PR DESCRIPTION
Fixed crash when failing to cache image

**AndroidRuntime: Caused by: com.facebook.react.bridge.UnexpectedNativeTypeException: Value for uri cannot be cast from ReadableNativeMap to String**

